### PR TITLE
Add calendar view to itinerary

### DIFF
--- a/src/components/trip/itinerary/CalendarView.tsx
+++ b/src/components/trip/itinerary/CalendarView.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { Calendar, momentLocalizer } from 'react-big-calendar';
+import moment from 'moment';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { Activity, Lodging, Transportation, Trip } from '../../../types/trips.ts';
+import { useQuery } from '@tanstack/react-query';
+import { listActivities, listLodgings, listTransportations } from '../../../lib';
+
+const localizer = momentLocalizer(moment);
+
+export const CalendarView = ({ trip }: { trip: Trip }) => {
+  const tripId = trip.id;
+  const { data: activities } = useQuery<Activity[]>({
+    queryKey: ['listActivities', tripId],
+    queryFn: () => listActivities(tripId || ''),
+  });
+
+  const { data: transportations } = useQuery<Transportation[]>({
+    queryKey: ['listTransportations', trip.id],
+    queryFn: () => listTransportations(trip.id || ''),
+  });
+
+  const { data: lodgings } = useQuery<Lodging[]>({
+    queryKey: ['listLodgings', tripId],
+    queryFn: () => listLodgings(tripId || ''),
+  });
+
+  const [events, setEvents] = useState<any[]>([]);
+
+  useEffect(() => {
+    const newEvents: any[] = [];
+
+    activities?.forEach((activity) => {
+      newEvents.push({
+        title: activity.name,
+        start: new Date(activity.startDate),
+        end: new Date(activity.endDate),
+        type: 'activity',
+      });
+    });
+
+    transportations?.forEach((transportation) => {
+      newEvents.push({
+        title: transportation.name,
+        start: new Date(transportation.departureTime),
+        end: new Date(transportation.arrivalTime),
+        type: 'transportation',
+      });
+    });
+
+    lodgings?.forEach((lodging) => {
+      newEvents.push({
+        title: lodging.name,
+        start: new Date(lodging.startDate),
+        end: new Date(lodging.endDate),
+        type: 'lodging',
+      });
+    });
+
+    setEvents(newEvents);
+  }, [activities, transportations, lodgings]);
+
+  return (
+    <div style={{ height: '100vh' }}>
+      <Calendar
+        localizer={localizer}
+        events={events}
+        startAccessor="start"
+        endAccessor="end"
+        style={{ height: 500 }}
+      />
+    </div>
+  );
+};

--- a/src/components/trip/itinerary/ItineraryView.tsx
+++ b/src/components/trip/itinerary/ItineraryView.tsx
@@ -1,5 +1,5 @@
 import { Activity, Lodging, Transportation, Trip } from '../../../types/trips.ts';
-import { Accordion, Group, Pagination, rem, Stack, Text } from '@mantine/core';
+import { Accordion, Button, Group, Pagination, rem, Stack, Text } from '@mantine/core';
 import { IconCalendar } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
@@ -9,10 +9,12 @@ import { buildActivitiesIndex, buildLodgingIndex, buildTransportationIndex, chun
 import { TransportationLine } from './TransportationLine.tsx';
 import { LodgingLine } from './LodgingLine.tsx';
 import { ActivityLine } from './ActivityLine.tsx';
+import { CalendarView } from './CalendarView.tsx';
 
 export const ItineraryView = ({ trip }: { trip: Trip }) => {
   const [tripWeeks, setTripWeeks] = useState<Array<Array<{ id: string; value: Dayjs }>>>([]);
   const [activePage, setPage] = useState(1);
+  const [viewMode, setViewMode] = useState<'list' | 'calendar'>('list');
 
   const tripId = trip.id;
   const { data: activities } = useQuery<Activity[]>({
@@ -61,52 +63,61 @@ export const ItineraryView = ({ trip }: { trip: Trip }) => {
 
   return (
     <>
-      <Pagination mt={'sm'} value={activePage} onChange={setPage} total={tripWeeks.length} withEdges />
-      <Accordion chevronPosition="right" variant="separated" multiple={true} mt={'sm'}>
-        {(tripWeeks[activePage - 1] || []).map((day) => {
-          return (
-            <Accordion.Item value={day.id} key={day.id}>
-              <Accordion.Control
-                icon={
-                  <IconCalendar
-                    style={{
-                      color: 'var(--mantine-primary-color-6)',
-                      width: rem(20),
-                      height: rem(20),
-                    }}
-                  />
-                }
-              >
-                <Group wrap="nowrap">
-                  <div>
-                    <Text>{day.value.format('LL')}</Text>
-                    <Text c={'dimmed'} size={'xs'}>
-                      {`Transportations: ${(transportationItinerary[day.value.toISOString()] || []).length}`} &nbsp;
-                      {`Lodgings: ${(lodgingsItinerary[day.value.toISOString()] || []).length}`} &nbsp;
-                      {`Activities: ${(activitiesItinerary[day.value.toISOString()] || []).length}`}
-                    </Text>
-                  </div>
-                </Group>
-              </Accordion.Control>
-              <Accordion.Panel>
-                <Stack>
-                  {(transportationItinerary[day.value.toISOString()] || []).map((tr) => {
-                    return <TransportationLine transportation={tr} day={day.value} />;
-                  })}
+      <Group position="apart" mt={'sm'}>
+        <Pagination value={activePage} onChange={setPage} total={tripWeeks.length} withEdges />
+        <Button onClick={() => setViewMode(viewMode === 'list' ? 'calendar' : 'list')}>
+          {viewMode === 'list' ? 'Switch to Calendar View' : 'Switch to List View'}
+        </Button>
+      </Group>
+      {viewMode === 'list' ? (
+        <Accordion chevronPosition="right" variant="separated" multiple={true} mt={'sm'}>
+          {(tripWeeks[activePage - 1] || []).map((day) => {
+            return (
+              <Accordion.Item value={day.id} key={day.id}>
+                <Accordion.Control
+                  icon={
+                    <IconCalendar
+                      style={{
+                        color: 'var(--mantine-primary-color-6)',
+                        width: rem(20),
+                        height: rem(20),
+                      }}
+                    />
+                  }
+                >
+                  <Group wrap="nowrap">
+                    <div>
+                      <Text>{day.value.format('LL')}</Text>
+                      <Text c={'dimmed'} size={'xs'}>
+                        {`Transportations: ${(transportationItinerary[day.value.toISOString()] || []).length}`} &nbsp;
+                        {`Lodgings: ${(lodgingsItinerary[day.value.toISOString()] || []).length}`} &nbsp;
+                        {`Activities: ${(activitiesItinerary[day.value.toISOString()] || []).length}`}
+                      </Text>
+                    </div>
+                  </Group>
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <Stack>
+                    {(transportationItinerary[day.value.toISOString()] || []).map((tr) => {
+                      return <TransportationLine transportation={tr} day={day.value} />;
+                    })}
 
-                  {(lodgingsItinerary[day.value.toISOString()] || []).map((tr) => {
-                    return <LodgingLine lodging={tr} day={day.value} />;
-                  })}
+                    {(lodgingsItinerary[day.value.toISOString()] || []).map((tr) => {
+                      return <LodgingLine lodging={tr} day={day.value} />;
+                    })}
 
-                  {(activitiesItinerary[day.value.toISOString()] || []).map((tr) => {
-                    return <ActivityLine activity={tr} day={day.value} />;
-                  })}
-                </Stack>
-              </Accordion.Panel>
-            </Accordion.Item>
-          );
-        })}
-      </Accordion>
+                    {(activitiesItinerary[day.value.toISOString()] || []).map((tr) => {
+                      return <ActivityLine activity={tr} day={day.value} />;
+                    })}
+                  </Stack>
+                </Accordion.Panel>
+              </Accordion.Item>
+            );
+          })}
+        </Accordion>
+      ) : (
+        <CalendarView trip={trip} />
+      )}
     </>
   );
 };

--- a/src/components/trip/itinerary/helper.ts
+++ b/src/components/trip/itinerary/helper.ts
@@ -48,7 +48,6 @@ export const buildActivitiesIndex = (activities: Activity[]) => {
   activities?.forEach((activity) => {
     const start = dayjs(activity.startDate).startOf('day');
 
-    // for (let m = dayjs(start); m.isBefore(end); m = m.add(1, 'day')) {
     const key = start.toISOString();
     let value = lodgingIndex[key];
     if (!value) {
@@ -59,7 +58,6 @@ export const buildActivitiesIndex = (activities: Activity[]) => {
     if (!exists) {
       lodgingIndex[key].push(activity);
     }
-    // }
   });
   return lodgingIndex;
 };
@@ -72,3 +70,40 @@ export function chunk<T>(array: T[], size: number): T[][] {
   const tail = array.slice(size);
   return [head, ...chunk(tail, size)];
 }
+
+export const buildCalendarEvents = (
+  activities: Activity[],
+  lodgings: Lodging[],
+  transportations: Transportation[]
+) => {
+  const events: any[] = [];
+
+  activities?.forEach((activity) => {
+    events.push({
+      title: activity.name,
+      start: new Date(activity.startDate),
+      end: new Date(activity.endDate),
+      type: 'activity',
+    });
+  });
+
+  transportations?.forEach((transportation) => {
+    events.push({
+      title: transportation.name,
+      start: new Date(transportation.departureTime),
+      end: new Date(transportation.arrivalTime),
+      type: 'transportation',
+    });
+  });
+
+  lodgings?.forEach((lodging) => {
+    events.push({
+      title: lodging.name,
+      start: new Date(lodging.startDate),
+      end: new Date(lodging.endDate),
+      type: 'lodging',
+    });
+  });
+
+  return events;
+};


### PR DESCRIPTION
Add a calendar view for the itinerary.

* **New CalendarView Component**: Add `CalendarView` component in `src/components/trip/itinerary/CalendarView.tsx` to render the itinerary as a calendar using `react-big-calendar`.
* **ItineraryView Component**: Modify `ItineraryView` in `src/components/trip/itinerary/ItineraryView.tsx` to include a toggle button for switching between list view and calendar view. Conditionally render the `CalendarView` or the existing list view based on the toggle state.
* **Helper Functions**: Update `src/components/trip/itinerary/helper.ts` to include a new `buildCalendarEvents` function to support calendar view logic.
* **Styling and Layout**: Adjust styling and layout in `ItineraryView` to accommodate the new calendar view.

