### PR TITLE
Add some currencies to currencyCodes.ts

### DIFF
--- a/src/components/account/UserSettingsForm.tsx
+++ b/src/components/account/UserSettingsForm.tsx
@@ -63,6 +63,7 @@ export const UserSettingsForm = () => {
           key={form.key('currencyCode')}
           {...form.getInputProps('currencyCode')}
           data={currencyCodes}
+          searchable
           withCheckIcon={false}
         />
 

--- a/src/components/util/CurrencyInput.tsx
+++ b/src/components/util/CurrencyInput.tsx
@@ -20,6 +20,7 @@ export const CurrencyInput = ({
       key={currencyCodeKey}
       {...currencyCodeProps}
       data={currencyCodes}
+      searchable
       rightSectionWidth={28}
       withCheckIcon={false}
       styles={{

--- a/src/components/util/currencyCodes.ts
+++ b/src/components/util/currencyCodes.ts
@@ -1,7 +1,159 @@
 export const currencyCodes = [
-  { value: 'USD', label: '🇺🇸 USD' },
-  { value: 'EUR', label: '🇪🇺 EUR' },
-  { value: 'CAD', label: '🇨🇦 CAD' },
-  { value: 'GBP', label: '🇬🇧 GBP' },
-  { value: 'AUD', label: '🇦🇺 AUD' },
+  { value: 'USD', label: '🇺🇸 USD' }, // United States Dollar
+  { value: 'EUR', label: '🇪🇺 EUR' }, // Euro
+  { value: 'JPY', label: '🇯🇵 JPY' }, // Japanese Yen
+  { value: 'GBP', label: '🇬🇧 GBP' }, // British Pound Sterling
+  { value: 'CNY', label: '🇨🇳 CNY' }, // Chinese Yuan
+  { value: 'AUD', label: '🇦🇺 AUD' }, // Australian Dollar
+  { value: 'CAD', label: '🇨🇦 CAD' }, // Canadian Dollar
+  { value: 'CHF', label: '🇨🇭 CHF' }, // Swiss Franc
+  { value: 'HKD', label: '🇭🇰 HKD' }, // Hong Kong Dollar
+  { value: 'NZD', label: '🇳🇿 NZD' }, // New Zealand Dollar
+  { value: 'SEK', label: '🇸🇪 SEK' }, // Swedish Krona
+  { value: 'KRW', label: '🇰🇷 KRW' }, // South Korean Won
+  { value: 'SGD', label: '🇸🇬 SGD' }, // Singapore Dollar
+  { value: 'NOK', label: '🇳🇴 NOK' }, // Norwegian Krone
+  { value: 'MXN', label: '🇲🇽 MXN' }, // Mexican Peso
+  { value: 'INR', label: '🇮🇳 INR' }, // Indian Rupee
+  { value: 'RUB', label: '🇷🇺 RUB' }, // Russian Ruble
+  { value: 'ZAR', label: '🇿🇦 ZAR' }, // South African Rand
+  { value: 'TRY', label: '🇹🇷 TRY' }, // Turkish Lira
+  { value: 'BRL', label: '🇧🇷 BRL' }, // Brazilian Real
+  { value: 'TWD', label: '🇹🇼 TWD' }, // New Taiwan Dollar
+  { value: 'DKK', label: '🇩🇰 DKK' }, // Danish Krone
+  { value: 'PLN', label: '🇵🇱 PLN' }, // Polish Złoty
+  { value: 'THB', label: '🇹🇭 THB' }, // Thai Baht
+  { value: 'IDR', label: '🇮🇩 IDR' }, // Indonesian Rupiah
+  { value: 'HUF', label: '🇭🇺 HUF' }, // Hungarian Forint
+  { value: 'CZK', label: '🇨🇿 CZK' }, // Czech Koruna
+  { value: 'ILS', label: '🇮🇱 ILS' }, // Israeli New Shekel
+  { value: 'CLP', label: '🇨🇱 CLP' }, // Chilean Peso
+  { value: 'PHP', label: '🇵🇭 PHP' }, // Philippine Peso
+  { value: 'AED', label: '🇦🇪 AED' }, // UAE Dirham
+  { value: 'COP', label: '🇨🇴 COP' }, // Colombian Peso
+  { value: 'SAR', label: '🇸🇦 SAR' }, // Saudi Riyal
+  { value: 'MYR', label: '🇲🇾 MYR' }, // Malaysian Ringgit
+  { value: 'RON', label: '🇷🇴 RON' }, // Romanian Leu
+  { value: 'ARS', label: '🇦🇷 ARS' }, // Argentine Peso
+  { value: 'BGN', label: '🇧🇬 BGN' }, // Bulgarian Lev
+  { value: 'DZD', label: '🇩🇿 DZD' }, // Algerian Dinar
+  { value: 'BHD', label: '🇧🇭 BHD' }, // Bahraini Dinar
+  { value: 'IQD', label: '🇮🇶 IQD' }, // Iraqi Dinar
+  { value: 'JOD', label: '🇯🇴 JOD' }, // Jordanian Dinar
+  { value: 'KWD', label: '🇰🇼 KWD' }, // Kuwaiti Dinar
+  { value: 'LYD', label: '🇱🇾 LYD' }, // Libyan Dinar
+  { value: 'OMR', label: '🇴🇲 OMR' }, // Omani Rial
+  { value: 'QAR', label: '🇶🇦 QAR' }, // Qatari Riyal
+  { value: 'TND', label: '🇹🇳 TND' }, // Tunisian Dinar
+  { value: 'VND', label: '🇻🇳 VND' }, // Vietnamese Dong
+  { value: 'EGP', label: '🇪🇬 EGP' }, // Egyptian Pound
+  { value: 'ISK', label: '🇮🇸 ISK' }, // Icelandic Króna
+  { value: 'KZT', label: '🇰🇿 KZT' }, // Kazakhstani Tenge
+  { value: 'LKR', label: '🇱🇰 LKR' }, // Sri Lankan Rupee
+  { value: 'MAD', label: '🇲🇦 MAD' }, // Moroccan Dirham
+  { value: 'NGN', label: '🇳🇬 NGN' }, // Nigerian Naira
+  { value: 'PKR', label: '🇵🇰 PKR' }, // Pakistani Rupee
+  { value: 'PEN', label: '🇵🇪 PEN' }, // Peruvian Sol
+  { value: 'UAH', label: '🇺🇦 UAH' }, // Ukrainian Hryvnia
+  { value: 'UYU', label: '🇺🇾 UYU' }, // Uruguayan Peso
+  { value: 'VES', label: '🇻🇪 VES' }, // Venezuelan Bolívar Soberano
+  { value: 'IRR', label: '🇮🇷 IRR' }, // Iranian Rial
+  { value: 'AFN', label: '🇦🇫 AFN' }, // Afghan Afghani
+  { value: 'ALL', label: '🇦🇱 ALL' }, // Albanian Lek
+  { value: 'AMD', label: '🇦🇲 AMD' }, // Armenian Dram
+  { value: 'AOA', label: '🇦🇴 AOA' }, // Angolan Kwanza
+  { value: 'AWG', label: '🇦🇼 AWG' }, // Aruban Florin
+  { value: 'AZN', label: '🇦🇿 AZN' }, // Azerbaijani Manat
+  { value: 'BAM', label: '🇧🇦 BAM' }, // Bosnia-Herzegovina Convertible Mark
+  { value: 'BBD', label: '🇧🇧 BBD' }, // Barbadian Dollar
+  { value: 'BDT', label: '🇧🇩 BDT' }, // Bangladeshi Taka
+  { value: 'BIF', label: '🇧🇮 BIF' }, // Burundian Franc
+  { value: 'BMD', label: '🇧🇲 BMD' }, // Bermudan Dollar
+  { value: 'BND', label: '🇧🇳 BND' }, // Brunei Dollar
+  { value: 'BOB', label: '🇧🇴 BOB' }, // Bolivian Boliviano
+  { value: 'BSD', label: '🇧🇸 BSD' }, // Bahamian Dollar
+  { value: 'BTN', label: '🇧🇹 BTN' }, // Bhutanese Ngultrum
+  { value: 'BWP', label: '🇧🇼 BWP' }, // Botswanan Pula
+  { value: 'BYN', label: '🇧🇾 BYN' }, // Belarusian Ruble
+  { value: 'BZD', label: '🇧🇿 BZD' }, // Belize Dollar
+  { value: 'CDF', label: '🇨🇩 CDF' }, // Congolese Franc
+  { value: 'CRC', label: '🇨🇷 CRC' }, // Costa Rican Colón
+  { value: 'CVE', label: '🇨🇻 CVE' }, // Cape Verdean Escudo
+  { value: 'DJF', label: '🇩🇯 DJF' }, // Djiboutian Franc
+  { value: 'DOP', label: '🇩🇴 DOP' }, // Dominican Peso
+  { value: 'ERN', label: '🇪🇷 ERN' }, // Eritrean Nakfa
+  { value: 'ETB', label: '🇪🇹 ETB' }, // Ethiopian Birr
+  { value: 'FJD', label: '🇫🇯 FJD' }, // Fijian Dollar
+  { value: 'FKP', label: '🇫🇰 FKP' }, // Falkland Islands Pound
+  { value: 'GEL', label: '🇬🇪 GEL' }, // Georgian Lari
+  { value: 'GHS', label: '🇬🇭 GHS' }, // Ghanaian Cedi
+  { value: 'GIP', label: '🇬🇮 GIP' }, // Gibraltar Pound
+  { value: 'GMD', label: '🇬🇲 GMD' }, // Gambian Dalasi
+  { value: 'GNF', label: '🇬🇳 GNF' }, // Guinean Franc
+  { value: 'GTQ', label: '🇬🇹 GTQ' }, // Guatemalan Quetzal
+  { value: 'GYD', label: '🇬🇾 GYD' }, // Guyanaese Dollar
+  { value: 'HNL', label: '🇭🇳 HNL' }, // Honduran Lempira
+  { value: 'HTG', label: '🇭🇹 HTG' }, // Haitian Gourde
+  { value: 'JMD', label: '🇯🇲 JMD' }, // Jamaican Dollar
+  { value: 'KES', label: '🇰🇪 KES' }, // Kenyan Shilling
+  { value: 'KGS', label: '🇰🇬 KGS' }, // Kyrgystani Som
+  { value: 'KHR', label: '🇰🇭 KHR' }, // Cambodian Riel
+  { value: 'KMF', label: '🇰🇲 KMF' }, // Comorian Franc
+  { value: 'KPW', label: '🇰🇵 KPW' }, // North Korean Won
+  { value: 'KYD', label: '🇰🇾 KYD' }, // Cayman Islands Dollar
+  { value: 'LAK', label: '🇱🇦 LAK' }, // Laotian Kip
+  { value: 'LBP', label: '🇱🇧 LBP' }, // Lebanese Pound
+  { value: 'LRD', label: '🇱🇷 LRD' }, // Liberian Dollar
+  { value: 'LSL', label: '🇱🇸 LSL' }, // Lesotho Loti
+  { value: 'MDL', label: '🇲🇩 MDL' }, // Moldovan Leu
+  { value: 'MGA', label: '🇲🇬 MGA' }, // Malagasy Ariary
+  { value: 'MKD', label: '🇲🇰 MKD' }, // Macedonian Denar
+  { value: 'MMK', label: '🇲🇲 MMK' }, // Myanmar Kyat
+  { value: 'MNT', label: '🇲🇳 MNT' }, // Mongolian Tugrik
+  { value: 'MOP', label: '🇲🇴 MOP' }, // Macanese Pataca
+  { value: 'MRU', label: '🇲🇷 MRU' }, // Mauritanian Ouguiya
+  { value: 'MUR', label: '🇲🇺 MUR' }, // Mauritian Rupee
+  { value: 'MVR', label: '🇲🇻 MVR' }, // Maldivian Rufiyaa
+  { value: 'MWK', label: '🇲🇼 MWK' }, // Malawian Kwacha
+  { value: 'MZN', label: '🇲🇿 MZN' }, // Mozambican Metical
+  { value: 'NAD', label: '🇳🇦 NAD' }, // Namibian Dollar
+  { value: 'NIO', label: '🇳🇮 NIO' }, // Nicaraguan Córdoba
+  { value: 'NPR', label: '🇳🇵 NPR' }, // Nepalese Rupee
+  { value: 'PGK', label: '🇵🇬 PGK' }, // Papua New Guinean Kina
+  { value: 'PYG', label: '🇵🇾 PYG' }, // Paraguayan Guarani
+  { value: 'RSD', label: '🇷🇸 RSD' }, // Serbian Dinar
+  { value: 'RWF', label: '🇷🇼 RWF' }, // Rwandan Franc
+  { value: 'SBD', label: '🇸🇧 SBD' }, // Solomon Islands Dollar
+  { value: 'SCR', label: '🇸🇨 SCR' }, // Seychellois Rupee
+  { value: 'SDG', label: '🇸🇩 SDG' }, // Sudanese Pound
+  { value: 'SHP', label: '🇸🇭 SHP' }, // Saint Helena Pound
+  { value: 'SLL', label: '🇸🇱 SLL' }, // Sierra Leonean Leone
+  { value: 'SOS', label: '🇸🇴 SOS' }, // Somali Shilling
+  { value: 'SRD', label: '🇸🇷 SRD' }, // Surinamese Dollar
+  { value: 'SSP', label: '🇸🇸 SSP' }, // South Sudanese Pound
+  { value: 'STN', label: '🇸🇹 STN' }, // São Tomé and Príncipe Dobra
+  { value: 'SYP', label: '🇸🇾 SYP' }, // Syrian Pound
+  { value: 'SZL', label: '🇸🇿 SZL' }, // Swazi Lilangeni
+  { value: 'TJS', label: '🇹🇯 TJS' }, // Tajikistani Somoni
+  { value: 'TMT', label: '🇹🇲 TMT' }, // Turkmenistani Manat
+  { value: 'TOP', label: '🇹🇴 TOP' }, // Tongan Paʻanga
+  { value: 'TTD', label: '🇹🇹 TTD' }, // Trinidad and Tobago Dollar
+  { value: 'TZS', label: '🇹🇿 TZS' }, // Tanzanian Shilling
+  { value: 'UGX', label: '🇺🇬 UGX' }, // Ugandan Shilling
+  { value: 'UZS', label: '🇺🇿 UZS' }, // Uzbekistani Som
+  { value: 'VUV', label: '🇻🇺 VUV' }, // Vanuatu Vatu
+  { value: 'WST', label: '🇼🇸 WST' }, // Samoan Tala
+  { value: 'XAF', label: '🌍 XAF' }, // Central African CFA Franc
+  { value: 'XCD', label: '🏝️ XCD' }, // East Caribbean Dollar
+  { value: 'XOF', label: '🌍 XOF' }, // West African CFA Franc
+  { value: 'XPF', label: '🇵🇫 XPF' }, // CFP Franc
+  { value: 'YER', label: '🇾🇪 YER' }, // Yemeni Rial
+  { value: 'ZMW', label: '🇿🇲 ZMW' }, // Zambian Kwacha
+  { value: 'ZWL', label: '🇿🇼 ZWL' }, // Zimbabwean Dollar
+  { value: 'KID', label: '🇰🇮 KID' }, // Kiribati Dollar
+  { value: 'CLF', label: '🇨🇱 CLF' }, // Chilean Unidad de Fomento
+  { value: 'CUP', label: '🇨🇺 CUP' }, // Cuban Peso
+  { value: 'GGP', label: '🇬🇬 GGP' }, // Guernsey Pound
+  { value: 'IMP', label: '🇮🇲 IMP' }, // Isle of Man Pound
+  { value: 'JEP', label: '🇯🇪 JEP' }, // Jersey Pound
 ];


### PR DESCRIPTION
I was wondering if it'll be possible to add some other currencies to the `currencyCodes.ts` file. While playing around in the demo app, I wanted to change the currency to an Asian currency but it was not listed.

Also, if this change is accepted, for Mantine, I would like to change the Select component that is used in `CurrencyInput.tsx` to NativeSelect as the list is tedious to scroll through if the currency that one wants to select is near the bottom