### PR TITLE
Fix: ensure endDate is always converted to browser date format

### DIFF
--- a/src/lib/api/pocketbase/activities.ts
+++ b/src/lib/api/pocketbase/activities.ts
@@ -16,6 +16,7 @@ export const listActivities = async (tripId: string): Promise<Activity[]> => {
     return {
       ...entry,
       startDate: convertSavedToBrowserDate(entry.startDate),
+      endDate: convertSavedToBrowserDate(entry.endDate),
     };
   });
 };

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -50,7 +50,10 @@ export const fakeAsUtcString = (date: string | undefined): string => {
   return dayjs(date, 'UTC').format('YYYY-MM-DDTHH:mm:ss[Z]');
 };
 
-export const convertSavedToBrowserDate = (dateString: string) => {
+export const convertSavedToBrowserDate = (dateString: string | undefined) => {
+  if (!dateString) {
+    return undefined;
+  }
   const d = dayjs.tz(dateString, 'UTC');
   return d.format('YYYY-MM-DDTHH:mm:ss');
 };


### PR DESCRIPTION
### Problem
When saving an activity, the end time would shift by the user's timezone offset while the start time remained correct.

### Root Cause
The `listActivities()` function was only converting `startDate` from UTC to browser format, but `endDate` was not being converted. 

### Solution
- Added `endDate` conversion in `listActivities()` to match the pattern used for `startDate` and align with how transportations and lodgings handle their date fields
- Updated `convertSavedToBrowserDate()` to safely handle `undefined` values

Fixes issue #225 