### PR TITLE
feat: announcements and user notifications feature

### DIFF
--- a/backend/app/surmai.go
+++ b/backend/app/surmai.go
@@ -121,6 +121,9 @@ func (surmai *SurmaiApp) BindEventHooks() {
 	surmai.Pb.OnRecordUpdateRequest("invitations").BindFunc(hooks.UpdateTripCollaborationInvitation)
 
 	surmai.Pb.OnRecordCreate("users").BindFunc(hooks.AssignTravellerProfileOnUserCreate)
+	surmai.Pb.OnRecordCreate("users").BindFunc(hooks.CreateNotificationsForNewUser)
+
+	surmai.Pb.OnRecordCreate("announcements").BindFunc(hooks.CreateNotificationsForAnnouncement)
 
 	surmai.Pb.OnRecordUpdateRequest("traveller_profiles").BindFunc(hooks.RestrictManagersUpdate)
 	surmai.Pb.OnRecordEnrich("traveller_profiles").BindFunc(hooks.EnrichTravellerProfileManagers)
@@ -131,7 +134,7 @@ func (surmai *SurmaiApp) StartJobs() {
 	surmai.startDemoModeSetupJob()
 	surmai.startSyncCurrencyConversionRatesJob()
 	surmai.startEmailSyncJob()
-
+	surmai.startCleanupExpiredContentJob()
 }
 
 func (surmai *SurmaiApp) startSyncCurrencyConversionRatesJob() {
@@ -188,6 +191,17 @@ func (surmai *SurmaiApp) startEmailSyncJob() {
 	// - a delay of max 15 mins is acceptable
 	// - we will finish processing a batch of emails in 15 minutes
 	surmai.Pb.Cron().MustAdd("ImportBookingsFromEmailJob", "*/15 * * * *", func() {
+		job.Execute()
+	})
+}
+
+func (surmai *SurmaiApp) startCleanupExpiredContentJob() {
+	job := &jobs.CleanupExpiredContentJob{
+		Pb: surmai.Pb,
+	}
+
+	// Run daily at 3am
+	surmai.Pb.Cron().MustAdd("CleanupExpiredContentJob", "0 3 * * *", func() {
 		job.Execute()
 	})
 }

--- a/backend/hooks/manage_notifications.go
+++ b/backend/hooks/manage_notifications.go
@@ -1,0 +1,97 @@
+package hooks
+
+import (
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func CreateNotificationsForNewUser(e *core.RecordEvent) error {
+	if err := e.Next(); err != nil {
+		return err
+	}
+
+	logger := e.App.Logger().WithGroup("CreateNotificationsForNewUser")
+	userId := e.Record.Id
+	now := time.Now().Format(time.RFC3339)
+
+	// Find all non-expired announcements
+	announcements, err := e.App.FindRecordsByFilter(
+		"announcements",
+		"expiry = '' || expiry > {:now}",
+		"-created",
+		0,
+		0,
+		dbx.Params{"now": now},
+	)
+
+	if err != nil {
+		return nil // No announcements or error
+	}
+
+	notificationsCollection, err := e.App.FindCollectionByNameOrId("notifications")
+	if err != nil {
+		return err
+	}
+
+	for _, announcement := range announcements {
+		notification := core.NewRecord(notificationsCollection)
+		notification.Set("userId", userId)
+		notification.Set("subject", announcement.GetString("subject"))
+		notification.Set("text", announcement.GetString("text"))
+		notification.Set("message", announcement.GetString("message"))
+		notification.Set("expiry", announcement.Get("expiry"))
+		notification.Set("sender", announcement.GetString("sender"))
+		notification.Set("read", false)
+
+		if err := e.App.Save(notification); err != nil {
+			logger.Error("Save error", "userId", userId, "announcementId", announcement.Id, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func CreateNotificationsForAnnouncement(e *core.RecordEvent) error {
+	if err := e.Next(); err != nil {
+		return err
+	}
+
+	logger := e.App.Logger().WithGroup("CreateNotificationsForAnnouncement")
+	announcement := e.Record
+	subject := announcement.GetString("subject")
+	text := announcement.GetString("text")
+	message := announcement.GetString("message")
+	expiry := announcement.Get("expiry")
+	sender := announcement.GetString("sender")
+
+	// Find all users
+	// Warning: this could be slow if there are many users
+	users, err := e.App.FindRecordsByFilter("users", "1=1", "", 0, 0)
+	if err != nil {
+		return err
+	}
+
+	notificationsCollection, err := e.App.FindCollectionByNameOrId("notifications")
+	if err != nil {
+		return err
+	}
+
+	for _, user := range users {
+		notification := core.NewRecord(notificationsCollection)
+		notification.Set("userId", user.Id)
+		notification.Set("subject", subject)
+		notification.Set("text", text)
+		notification.Set("message", message)
+		notification.Set("expiry", expiry)
+		notification.Set("sender", sender)
+		notification.Set("read", false)
+
+		if err := e.App.Save(notification); err != nil {
+			logger.Error("Save error", "userId", user.Id, "announcementId", announcement.Id, "error", err)
+		}
+	}
+
+	return nil
+}

--- a/backend/jobs/cleanup_expired_content_job.go
+++ b/backend/jobs/cleanup_expired_content_job.go
@@ -1,0 +1,48 @@
+package jobs
+
+import (
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase"
+)
+
+type CleanupExpiredContentJob struct {
+	Pb *pocketbase.PocketBase
+}
+
+func (job *CleanupExpiredContentJob) Execute() {
+	app := job.Pb.App
+	logger := app.Logger().WithGroup("CleanupExpiredContentJob")
+	now := time.Now()
+
+	// Delete all expired announcements
+	expiredAnnouncements, err := app.FindAllRecords("announcements",
+		dbx.NewExp("expiry < {:now}", dbx.Params{"now": now}))
+
+	if err != nil {
+		logger.Error("FindAllRecords error", "error", err)
+	} else {
+		for _, announcement := range expiredAnnouncements {
+			if err := app.Delete(announcement); err != nil {
+				logger.Error("Delete error", "announcementId", announcement.Id, "error", err)
+			}
+		}
+		logger.Info("Deleted expired announcements", "count", len(expiredAnnouncements))
+	}
+
+	// Delete all expired notifications
+	expiredNotifications, err := app.FindAllRecords("notifications",
+		dbx.NewExp("expiry < {:now}", dbx.Params{"now": now}))
+
+	if err != nil {
+		logger.Error("FindAllRecords error", "error", err)
+	} else {
+		for _, notification := range expiredNotifications {
+			if err := app.Delete(notification); err != nil {
+				logger.Error("Delete error", "notificationId", notification.Id, "error", err)
+			}
+		}
+		logger.Info("Deleted expired notifications", "count", len(expiredNotifications))
+	}
+}

--- a/backend/jobs/cleanup_invitations_job.go
+++ b/backend/jobs/cleanup_invitations_job.go
@@ -1,9 +1,10 @@
 package jobs
 
 import (
+	"time"
+
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
-	"time"
 )
 
 type CleanupInvitationsJob struct {
@@ -11,27 +12,43 @@ type CleanupInvitationsJob struct {
 }
 
 func (job *CleanupInvitationsJob) Execute() {
+	app := job.Pb.App
+	logger := app.Logger().WithGroup("CleanupInvitationsJob")
+	now := time.Now()
 
 	// get all invitations past expiry date
 	// mark them expired if still open
-	app := job.Pb.App
-	expiredInvitations, _ := app.FindAllRecords("invitations",
-		dbx.NewExp("expiresOn < {:currentTime} and status = {:status} ",
-			dbx.Params{"currentTime": time.Now(), "status": "open"}))
+	expiredInvitations, err := app.FindAllRecords("invitations",
+		dbx.NewExp("expiresOn < {:currentTime} and status = {:status}",
+			dbx.Params{"currentTime": now, "status": "open"}))
 
-	for _, invitation := range expiredInvitations {
-		invitation.Set("status", "expired")
-		_ = app.Save(invitation)
+	if err != nil {
+		logger.Error("FindAllRecords error", "error", err)
+	} else {
+		for _, invitation := range expiredInvitations {
+			invitation.Set("status", "expired")
+			if err := app.Save(invitation); err != nil {
+				logger.Error("Save error", "invitationId", invitation.Id, "error", err)
+			}
+		}
+		logger.Info("Marked invitations as expired", "count", len(expiredInvitations))
 	}
 
 	// get all non-open invitations 1 week past the expiry date
 	// delete these records
-	deletionCandidates, _ := app.FindAllRecords("invitations",
+	deletionThreshold := now.Add(-7 * 24 * time.Hour)
+	deletionCandidates, err := app.FindAllRecords("invitations",
 		dbx.NewExp("expiresOn < {:deletionThreshold}",
-			dbx.Params{"deletionThreshold": time.Now().Add(-7 * 24 * time.Hour)}))
+			dbx.Params{"deletionThreshold": deletionThreshold}))
 
-	for _, invitation := range deletionCandidates {
-		_ = app.Delete(invitation)
+	if err != nil {
+		logger.Error("FindAllRecords error", "error", err)
+	} else {
+		for _, invitation := range deletionCandidates {
+			if err := app.Delete(invitation); err != nil {
+				logger.Error("Delete error", "invitationId", invitation.Id, "error", err)
+			}
+		}
+		logger.Info("Deleted expired invitations", "count", len(deletionCandidates))
 	}
-
 }

--- a/backend/migrations/1775536243_create_notifications_and_announcements.go
+++ b/backend/migrations/1775536243_create_notifications_and_announcements.go
@@ -1,0 +1,109 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+
+		users, err := app.FindCollectionByNameOrId("users")
+		if err != nil {
+			return err
+		}
+
+		// 1. Create notifications collection
+		notifications := core.NewBaseCollection("notifications")
+		notifications.Fields.Add(
+			&core.RelationField{
+				Name:          "userId",
+				CollectionId:  users.Id,
+				CascadeDelete: true,
+				Required:      true,
+				MaxSelect:     1,
+			},
+			&core.TextField{
+				Name:     "subject",
+				Required: true,
+			},
+			&core.TextField{
+				Name: "text",
+			},
+			&core.TextField{
+				Name: "message",
+			},
+			&core.DateField{
+				Name: "expiry",
+			},
+			&core.TextField{
+				Name: "sender",
+			},
+			&core.BoolField{
+				Name: "read",
+			},
+		)
+		notifications.ListRule = types.Pointer("userId = @request.auth.id")
+		notifications.ViewRule = types.Pointer("userId = @request.auth.id")
+		notifications.UpdateRule = types.Pointer("userId = @request.auth.id")
+		notifications.DeleteRule = types.Pointer("userId = @request.auth.id")
+		notifications.CreateRule = types.Pointer("userId = @request.auth.id") // Users can create notifications for themselves? Or maybe only system?
+		// Better to allow admin to create for anyone.
+		// System sender will be handled by backend.
+
+		if err := app.Save(notifications); err != nil {
+			return err
+		}
+
+		// 3. Create announcements collection
+		announcements := core.NewBaseCollection("announcements")
+		announcements.Fields.Add(
+			&core.TextField{
+				Name:     "subject",
+				Required: true,
+			},
+			&core.TextField{
+				Name: "text",
+			},
+			&core.TextField{
+				Name: "message",
+			},
+			&core.DateField{
+				Name: "expiry",
+			},
+			&core.TextField{
+				Name: "sender",
+			},
+		)
+		// Only admins can manage announcements, everyone can view
+		announcements.ListRule = types.Pointer("@request.auth.id != ''")
+		announcements.ViewRule = types.Pointer("@request.auth.id != ''")
+		// announcements.CreateRule, UpdateRule, DeleteRule are empty (only superusers)
+
+		if err := app.Save(announcements); err != nil {
+			return err
+		}
+
+		return nil
+	}, func(app core.App) error {
+		// Rollback
+		notifications, _ := app.FindCollectionByNameOrId("notifications")
+		if notifications != nil {
+			app.Delete(notifications)
+		}
+
+		announcements, _ := app.FindCollectionByNameOrId("announcements")
+		if announcements != nil {
+			app.Delete(announcements)
+		}
+
+		users, _ := app.FindCollectionByNameOrId("users")
+		if users != nil {
+			users.Fields.RemoveByName("lastLogin")
+			app.Save(users)
+		}
+
+		return nil
+	})
+}

--- a/backend/migrations/1775536244_add_created_updated_timestamps.go
+++ b/backend/migrations/1775536244_add_created_updated_timestamps.go
@@ -1,0 +1,60 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		// 1. Add created and updated fields to announcements collection
+		announcements, err := app.FindCollectionByNameOrId("announcements")
+		if err != nil {
+			return err
+		}
+
+		if announcements.Fields.GetByName("created") == nil {
+			announcements.Fields.Add(&core.AutodateField{
+				Name:     "created",
+				OnCreate: true,
+				OnUpdate: false,
+			})
+		}
+		if announcements.Fields.GetByName("updated") == nil {
+			announcements.Fields.Add(&core.AutodateField{
+				Name:     "updated",
+				OnCreate: true,
+				OnUpdate: true,
+			})
+		}
+		if err := app.Save(announcements); err != nil {
+			return err
+		}
+
+		// 2. Add created and updated fields to notifications collection
+		notifications, err := app.FindCollectionByNameOrId("notifications")
+		if err != nil {
+			return err
+		}
+
+		if notifications.Fields.GetByName("created") == nil {
+			notifications.Fields.Add(&core.AutodateField{
+				Name:     "created",
+				OnCreate: true,
+				OnUpdate: false,
+			})
+		}
+		if notifications.Fields.GetByName("updated") == nil {
+			notifications.Fields.Add(&core.AutodateField{
+				Name:     "updated",
+				OnCreate: true,
+				OnUpdate: true,
+			})
+		}
+		if err := app.Save(notifications); err != nil {
+			return err
+		}
+
+		return nil
+	}, nil)
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,11 +22,11 @@ import { useSurmaiContext } from './app/useSurmaiContext.ts';
 import { useCurrentUser } from './auth/useCurrentUser.ts';
 import { Error } from './components/error/Error.tsx';
 import { Navbar } from './components/nav/Navbar.tsx';
+import { NotificationIndicator } from './components/notifications/NotificationIndicator.tsx';
 import { UserInfo } from './components/user/UserInfo.tsx';
 import { useDefaultPageTitle } from './lib/hooks/usePageTitle.ts';
 import { updateDayJsLanguage } from './lib/i18n.ts';
-import type {
-  MantineColorScheme} from '@mantine/core';
+import type { MantineColorScheme } from '@mantine/core';
 
 function App() {
   const [opened, { toggle, close }] = useDisclosure();
@@ -87,6 +87,7 @@ function App() {
               <Box component="div" id={'app-header'} />
             </Group>
             <Group gap={'xs'} mt={'sm'} visibleFrom={'xs'}>
+              <NotificationIndicator />
               <UserInfo />
             </Group>
           </Group>

--- a/src/components/notifications/NotificationIndicator.tsx
+++ b/src/components/notifications/NotificationIndicator.tsx
@@ -1,0 +1,35 @@
+import { ActionIcon, Indicator } from '@mantine/core';
+import { useQuery } from '@tanstack/react-query';
+import { IconBell } from '@tabler/icons-react';
+import { useNavigate } from 'react-router-dom';
+import { listNotifications } from '../../lib/api';
+import { useCurrentUser } from '../../auth/useCurrentUser';
+import type { Notification } from '../../types/notifications';
+
+export const NotificationIndicator = () => {
+  const { user } = useCurrentUser();
+  const navigate = useNavigate();
+
+  const { data: notifications = [] } = useQuery<Notification[]>({
+    queryKey: ['notifications'],
+    queryFn: listNotifications,
+    enabled: !!user,
+  });
+
+  const newNotificationsCount = notifications.filter((n) => !n.read).length;
+
+  return (
+    <Indicator
+      inline
+      label={newNotificationsCount}
+      size={20}
+      disabled={newNotificationsCount === 0}
+      offset={4}
+      withBorder
+    >
+      <ActionIcon variant="subtle" onClick={() => navigate('/profile#notifications')} title="Notifications">
+        <IconBell size={24} />
+      </ActionIcon>
+    </Indicator>
+  );
+};

--- a/src/components/notifications/UserNotifications.tsx
+++ b/src/components/notifications/UserNotifications.tsx
@@ -1,0 +1,74 @@
+import { Accordion, Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { listNotifications, markNotificationAsRead } from '../../lib/api';
+import type { Notification } from '../../types/notifications';
+import dayjs from 'dayjs';
+
+export const UserNotifications = () => {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const { data: notifications = [] } = useQuery<Notification[]>({
+    queryKey: ['notifications'],
+    queryFn: listNotifications,
+  });
+
+  const markAsReadMutation = useMutation({
+    mutationFn: markNotificationAsRead,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+
+  const handleToggle = (id: string | null) => {
+    if (id) {
+      const notification = notifications.find((n) => n.id === id);
+      if (notification && !notification.read) {
+        markAsReadMutation.mutate(id);
+      }
+    }
+  };
+
+  return (
+    <Stack>
+      {notifications.length === 0 ? (
+        <Text c="dimmed">{t('no_notifications', 'No notifications')}</Text>
+      ) : (
+        <Accordion onChange={handleToggle}>
+          {notifications.map((notification) => (
+            <Accordion.Item key={notification.id} value={notification.id}>
+              <Accordion.Control>
+                <Group justify="space-between">
+                  <Box>
+                    <Text fw={notification.read ? 400 : 700}>{notification.subject}</Text>
+                    <Text size="xs" c="dimmed">
+                      {notification.sender} • {dayjs(notification.created).fromNow()}
+                    </Text>
+                  </Box>
+                  {!notification.read && (
+                    <Badge color="blue" size="sm">
+                      {t('new', 'New')}
+                    </Badge>
+                  )}
+                </Group>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <Stack gap="xs">
+                  <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                    {notification.message || notification.text}
+                  </Text>
+                  {notification.expiry && (
+                    <Text size="xs" c="dimmed">
+                      {t('expires_at', 'Expires at')}: {dayjs(notification.expiry).format('LLL')}
+                    </Text>
+                  )}
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
+          ))}
+        </Accordion>
+      )}
+    </Stack>
+  );
+};

--- a/src/components/settings/Announcements.tsx
+++ b/src/components/settings/Announcements.tsx
@@ -1,0 +1,157 @@
+import {
+  Button,
+  Card,
+  Group,
+  LoadingOverlay,
+  Modal,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Textarea,
+  Title,
+} from '@mantine/core';
+import { DateInput } from '@mantine/dates';
+import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
+import { createAnnouncement, listAnnouncements } from '../../lib/api';
+import type { Announcement } from '../../types/notifications';
+import { useCurrentUser } from '../../auth/useCurrentUser';
+
+export const Announcements = () => {
+  const { t } = useTranslation();
+  const { user } = useCurrentUser();
+  const queryClient = useQueryClient();
+  const [opened, { open, close }] = useDisclosure(false);
+
+  const { isPending: fetchAnnouncementsPending, data: announcements = [] } = useQuery<Announcement[]>({
+    queryKey: ['announcements'],
+    queryFn: listAnnouncements,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createAnnouncement,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['announcements'] });
+    },
+  });
+
+  const form = useForm({
+    initialValues: {
+      subject: '',
+      text: '',
+      message: '',
+      expiry: null as string | null,
+      sender: user?.name || 'Administrator',
+    },
+    validate: {
+      subject: (value) => (value.length < 1 ? t('subject_required', 'Subject is required') : null),
+    },
+  });
+
+  const handleCreate = async (values: typeof form.values) => {
+    try {
+      await createMutation.mutateAsync({
+        ...values,
+        expiry: values.expiry ? values.expiry : dayjs().add(7, 'day').toDate().toISOString(),
+      });
+      notifications.show({
+        title: t('success', 'Success'),
+        message: t('announcement_created', 'Announcement created successfully'),
+        color: 'green',
+      });
+      close();
+      form.reset();
+    } catch (error) {
+      console.error(error);
+      notifications.show({
+        title: t('error', 'Error'),
+        message: t('announcement_create_failed', 'Failed to create announcement'),
+        color: 'red',
+      });
+    }
+  };
+
+  const rows = announcements.map((item) => (
+    <Table.Tr key={item.id}>
+      <Table.Td>{item.subject}</Table.Td>
+      <Table.Td>{item.sender}</Table.Td>
+      <Table.Td>{dayjs(item.created).format('L')}</Table.Td>
+      <Table.Td>{item.expiry ? dayjs(item.expiry).format('L') : '-'}</Table.Td>
+    </Table.Tr>
+  ));
+
+  return (
+    <Card withBorder radius="md" p="xl" mt={'md'}>
+      <Stack mt="md">
+        <Group justify="space-between">
+          <Title order={4}>{t('announcements', 'Announcements')}</Title>
+          <Button onClick={open}>{t('create_announcement', 'Create Announcement')}</Button>
+        </Group>
+
+        <LoadingOverlay
+          visible={fetchAnnouncementsPending}
+          zIndex={1000}
+          overlayProps={{ radius: 'sm', blur: 2 }}
+          loaderProps={{ type: 'bars' }}
+        />
+
+        <ScrollArea mt={'md'}>
+          <Table miw={800} verticalSpacing="sm" striped>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>{t('subject', 'Subject')}</Table.Th>
+                <Table.Th>{t('sender', 'Sender')}</Table.Th>
+                <Table.Th>{t('created', 'Created')}</Table.Th>
+                <Table.Th>{t('expiry', 'Expiry')}</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows}
+              {announcements.length === 0 && (
+                <Table.Tr>
+                  <Table.Td colSpan={4}>
+                    <Text c="dimmed" ta="center">
+                      {t('no_announcements', 'No announcements')}
+                    </Text>
+                  </Table.Td>
+                </Table.Tr>
+              )}
+            </Table.Tbody>
+          </Table>
+        </ScrollArea>
+
+        <Modal opened={opened} onClose={close} title={t('create_announcement', 'Create Announcement')} size={'xl'}>
+          <form onSubmit={form.onSubmit(handleCreate)}>
+            <Stack>
+              <TextInput label={t('subject', 'Subject')} required {...form.getInputProps('subject')} />
+              <TextInput label={t('summary', 'Summary (Short Text)')} {...form.getInputProps('text')} />
+              <Textarea
+                label={t('message', 'Full Message')}
+                resize="vertical"
+                minRows={5}
+                {...form.getInputProps('message')}
+              />
+              <DateInput
+                label={t('expiry_date', 'Expiry Date')}
+                {...form.getInputProps('expiry')}
+                clearable
+                minDate={dayjs().format('YYYY-MM-DD')}
+              />
+              <Group justify="flex-end">
+                <Button type="submit" loading={createMutation.isPending}>
+                  {t('create', 'Create')}
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Modal>
+      </Stack>
+    </Card>
+  );
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -134,5 +134,11 @@ export {
   uploadTravellerAttachments,
 } from './pocketbase/traveller_profiles.ts';
 
+export {
+  listNotifications,
+  markNotificationAsRead,
+  createAnnouncement,
+  listAnnouncements,
+} from './pocketbase/notifications.ts';
 
-export * from './pocketbase/assistant.ts'
+export * from './pocketbase/assistant.ts';

--- a/src/lib/api/pocketbase/notifications.ts
+++ b/src/lib/api/pocketbase/notifications.ts
@@ -1,0 +1,24 @@
+import { pb, pbAdmin } from './pocketbase';
+import type { Notification, Announcement } from '../../../types/notifications';
+
+export const listNotifications = async () => {
+  return await pb.collection('notifications').getFullList<Notification>({
+    sort: '-created',
+  });
+};
+
+export const markNotificationAsRead = async (id: string) => {
+  return await pb.collection('notifications').update(id, {
+    read: true,
+  });
+};
+
+export const createAnnouncement = async (announcement: Partial<Announcement>) => {
+  return await pbAdmin.collection('announcements').create(announcement);
+};
+
+export const listAnnouncements = async () => {
+  return await pb.collection('announcements').getFullList<Announcement>({
+    sort: '-created',
+  });
+};

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -1,10 +1,11 @@
 import { Container, Tabs, Text } from '@mantine/core';
-import { IconAdjustmentsPlus, IconKey, IconSettings, IconUsers } from '@tabler/icons-react';
+import { IconAdjustmentsPlus, IconBell, IconKey, IconSettings, IconUsers } from '@tabler/icons-react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Header } from '../../components/nav/Header.tsx';
+import { Announcements } from '../../components/settings/Announcements.tsx';
 import { Configuration } from '../../components/settings/Configuration.tsx';
 import { Datasets } from '../../components/settings/Datasets.tsx';
 import { ThirdPartyIntegrations } from '../../components/settings/ThirdPartyIntegrations.tsx';
@@ -17,7 +18,7 @@ const Settings = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { hash } = useLocation();
-  const validTabs = ['users', 'configuration', 'datasets', 'integrations', 'assistant'];
+  const validTabs = ['users', 'configuration', 'datasets', 'integrations', 'assistant', 'announcements'];
   const fragment = hash.slice(1);
   const activeTab = validTabs.includes(fragment) ? fragment : validTabs[0];
   usePageTitle(t('site_settings', 'Site Settings'));
@@ -59,6 +60,9 @@ const Settings = () => {
           <Tabs.Tab value="assistant" leftSection={<IconAdjustmentsPlus size={12} />}>
             {t('assistant', 'Assistant')}
           </Tabs.Tab>
+          <Tabs.Tab value="announcements" leftSection={<IconBell size={12} />}>
+            {t('announcements', 'Announcements')}
+          </Tabs.Tab>
         </Tabs.List>
         <Tabs.Panel value="users">
           <UserList />
@@ -74,6 +78,9 @@ const Settings = () => {
         </Tabs.Panel>
         <Tabs.Panel value="assistant">
           <AssistantConfiguration />
+        </Tabs.Panel>
+        <Tabs.Panel value="announcements">
+          <Announcements />
         </Tabs.Panel>
       </Tabs>
     </Container>

--- a/src/pages/UserProfile/UserProfile.tsx
+++ b/src/pages/UserProfile/UserProfile.tsx
@@ -1,5 +1,5 @@
 import { Container, Paper, SimpleGrid, Tabs, Text, Title } from '@mantine/core';
-import { IconEPassport, IconInfoCircle, IconKey } from '@tabler/icons-react';
+import { IconBell, IconEPassport, IconInfoCircle, IconKey } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -7,6 +7,7 @@ import { ChangePasswordForm } from '../../components/account/ChangePasswordForm.
 import { UserAvatarForm } from '../../components/account/UserAvatarForm.tsx';
 import { UserSettingsForm } from '../../components/account/UserSettingsForm.tsx';
 import { Header } from '../../components/nav/Header.tsx';
+import { UserNotifications } from '../../components/notifications/UserNotifications.tsx';
 import { MyTravelProfile } from '../../components/traveller/MyTravelProfile.tsx';
 import { usePageTitle } from '../../lib/hooks/usePageTitle.ts';
 
@@ -14,7 +15,7 @@ export const UserProfile = () => {
   const { t } = useTranslation();
   const { hash } = useLocation();
   const navigate = useNavigate();
-  const validTabs = ['basic_info', 'security', 'travel_info'];
+  const validTabs = ['basic_info', 'security', 'travel_info', 'notifications'];
   const fragment = hash.slice(1);
   const activeTab = validTabs.includes(fragment) ? fragment : validTabs[0];
   usePageTitle(t('settings', 'Settings'));
@@ -36,6 +37,9 @@ export const UserProfile = () => {
           </Tabs.Tab>
           <Tabs.Tab value="travel_info" leftSection={<IconEPassport size={12} />}>
             {t('travel_info', 'Travel Info')}
+          </Tabs.Tab>
+          <Tabs.Tab value="notifications" leftSection={<IconBell size={12} />}>
+            {t('notifications', 'Notifications')}
           </Tabs.Tab>
         </Tabs.List>
         <Tabs.Panel value="basic_info">
@@ -59,9 +63,20 @@ export const UserProfile = () => {
               {t('my_travel_info', 'My Travel Info')}
             </Title>
             <Text size="sm" c="dimmed" mb="md">
-              {t('my_travel_info_desc', 'Store your travel documents and ID numbers for easy access when booking trips.')}
+              {t(
+                'my_travel_info_desc',
+                'Store your travel documents and ID numbers for easy access when booking trips.'
+              )}
             </Text>
             <MyTravelProfile />
+          </Paper>
+        </Tabs.Panel>
+        <Tabs.Panel value="notifications">
+          <Paper withBorder radius="md" p="xl" bg={'var(--mantine-color-body)'} mt={'md'}>
+            <Title order={4} mb="md">
+              {t('Notifications', 'Notifications')}
+            </Title>
+            <UserNotifications />
           </Paper>
         </Tabs.Panel>
       </Tabs>

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,23 @@
+export type Notification = {
+  id: string;
+  created: string;
+  updated: string;
+  userId: string;
+  subject: string;
+  text: string;
+  message: string;
+  expiry: string;
+  sender: string;
+  read: boolean;
+};
+
+export type Announcement = {
+  id: string;
+  created: string;
+  updated: string;
+  subject: string;
+  text: string;
+  message: string;
+  expiry: string;
+  sender: string;
+};


### PR DESCRIPTION
- New `notifications` collection: Users receive notifications with subject, text, message, expiry, sender, and read status
- New `announcements` collection: Admin-visible announcements with created/updated timestamps
- Frontend components: `NotificationIndicator` (nav bar badge showing unread count), `UserNotifications` (accordion view), `Announcements` (admin table)
- Backend: Auto-create notifications for new users from active announcements, auto-create notifications when announcements are created
- Cleanup job: Daily job to delete expired announcements and notifications
- Converted data fetching to TanStack Query hooks in notification components