### PR TITLE
fix: changed the DateTimePicker to be modal

### DIFF
--- a/src/components/trip/activities/GenericActivityForm.tsx
+++ b/src/components/trip/activities/GenericActivityForm.tsx
@@ -148,6 +148,7 @@ export const GenericActivityForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'startDate'}
             label={t('activity_start_date', 'Start Date')}
@@ -167,6 +168,7 @@ export const GenericActivityForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'endDate'}
             label={t('activity_end_date', 'End Date')}

--- a/src/components/trip/lodging/GenericLodgingForm.tsx
+++ b/src/components/trip/lodging/GenericLodgingForm.tsx
@@ -146,6 +146,7 @@ export const GenericLodgingForm = ({
 
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'startDate'}
             label={t('lodging_start_date', 'Check-In')}
@@ -165,6 +166,7 @@ export const GenericLodgingForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'endDate'}
             label={t('lodging_end_date', 'Check-Out')}

--- a/src/components/trip/transportation/BikeForm.tsx
+++ b/src/components/trip/transportation/BikeForm.tsx
@@ -181,6 +181,7 @@ export const BikeForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'departureTime'}
             description={t('departure_time_desc', 'Departure date and time')}
@@ -201,6 +202,7 @@ export const BikeForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'arrivalTime'}
             label={t('transportation_arrival_time', 'Arrival')}

--- a/src/components/trip/transportation/CarRentalForm.tsx
+++ b/src/components/trip/transportation/CarRentalForm.tsx
@@ -152,6 +152,7 @@ export const CarRentalForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="DD MMM YYYY hh:mm A"
             name={'pickupTime'}
             label={t('transportation_pickup_time', 'Pickup Time')}
@@ -171,6 +172,7 @@ export const CarRentalForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="DD MMM YYYY hh:mm A"
             name={'dropOffTime'}
             label={t('transportation_dropOff_time', 'Drop Off Time')}

--- a/src/components/trip/transportation/FlightForm.tsx
+++ b/src/components/trip/transportation/FlightForm.tsx
@@ -208,6 +208,7 @@ export const FlightForm = ({
 
           <Grid.Col span={{ base: 12, md: 6 }}>
             <DateTimePicker
+              dropdownType="modal"
               valueFormat="lll"
               name={'departureTime'}
               description={t('departure_time_desc', 'Departure date and time')}
@@ -236,6 +237,7 @@ export const FlightForm = ({
           </Grid.Col>
           <Grid.Col span={{ base: 12, md: 6 }}>
             <DateTimePicker
+              dropdownType="modal"
               valueFormat="lll"
               name={'arrivalTime'}
               label={t('transportation_arrival_time', 'Arrival')}

--- a/src/components/trip/transportation/GenericTransportationModeForm.tsx
+++ b/src/components/trip/transportation/GenericTransportationModeForm.tsx
@@ -178,6 +178,7 @@ export const GenericTransportationModeForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'departureTime'}
             description={t('departure_time_desc', 'Departure date and time')}
@@ -198,6 +199,7 @@ export const GenericTransportationModeForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="lll"
             name={'arrivalTime'}
             label={t('transportation_arrival_time', 'Arrival')}

--- a/src/components/trip/transportation/ParkingForm.tsx
+++ b/src/components/trip/transportation/ParkingForm.tsx
@@ -171,6 +171,7 @@ export const ParkingForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="DD MMM YYYY hh:mm A"
             name={'startDate'}
             label={t('parking_start_date', 'Start Date')}
@@ -190,6 +191,7 @@ export const ParkingForm = ({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 6 }}>
           <DateTimePicker
+            dropdownType="modal"
             valueFormat="DD MMM YYYY hh:mm A"
             name={'endDate'}
             label={t('parking_end_date', 'End Date')}


### PR DESCRIPTION
The PWA version of the app was being finicky with
the Popover way of picking date and times. The numeric keyboard would not display half he time. Changing it to modal fixed it.