### PR TITLE
fix: standardize cost formatting

### DIFF
--- a/src/components/trip/activities/GenericActivityData.tsx
+++ b/src/components/trip/activities/GenericActivityData.tsx
@@ -16,6 +16,7 @@ import { useCurrentUser } from '../../../auth/useCurrentUser.ts';
 import { getMapsLink } from '../../../lib/places.ts';
 
 import type { Activity, Attachment, Expense, TravellerProfile, Trip } from '../../../types/trips.ts';
+import { formatCost } from '../expenses/helper.ts';
 
 export const GenericActivityData = ({
   trip,
@@ -43,8 +44,6 @@ export const GenericActivityData = ({
 
   // Get expense from map, handle null/undefined cases
   const expense = activity.expenseId ? expenseMap.get(activity.expenseId) : undefined;
-  const costValue = expense?.cost?.value;
-  const costCurrency = expense?.cost?.currency;
 
   return (
     <DataLine
@@ -156,7 +155,7 @@ export const GenericActivityData = ({
           <Text size="xs" c={'dimmed'}>
             {t('cost', 'Cost')}
           </Text>
-          <Text size="md">{costValue ? `${costValue} ${costCurrency || ''}` : ''}</Text>
+          <Text size="md">{formatCost(expense?.cost)}</Text>
         </Grid.Col>
       </Grid>
       <TravellerBadges travellerIds={activity.travellers} tripTravellers={tripTravellers} />

--- a/src/components/trip/basic/BasicInfoView.tsx
+++ b/src/components/trip/basic/BasicInfoView.tsx
@@ -12,6 +12,7 @@ import { useTripExpenses } from '../expenses/useTripExpenses.ts';
 
 import type { User } from '../../../types/auth.ts';
 import type { Trip } from '../../../types/trips.ts';
+import { formatCost } from '../expenses/helper.ts';
 
 export const BasicInfoView = ({ trip, refetch }: { trip: Trip; refetch: () => void }) => {
   const { t } = useTranslation();
@@ -97,11 +98,7 @@ export const BasicInfoView = ({ trip, refetch }: { trip: Trip; refetch: () => vo
                   </Text>
 
                   <Group gap={0}>
-                    <Text fw={700}>{trip.budget.value.toFixed(2)}</Text>
-                    <Text fw={700}>&nbsp;</Text>
-                    <Text fw={700} size="sm">
-                      {` ${trip.budget.currency}`}
-                    </Text>
+                    <Text fw={700}>{formatCost({value: trip.budget?.value, currency: trip.budget.currency})}</Text>
                   </Group>
                 </Box>
 
@@ -111,11 +108,7 @@ export const BasicInfoView = ({ trip, refetch }: { trip: Trip; refetch: () => vo
                   </Text>
 
                   <Group gap={0}>
-                    <Text fw={700}>{totalExpenses?.toFixed(2)}</Text>
-                    <Text fw={700}>&nbsp;</Text>
-                    <Text fw={700} size="sm">
-                      {` ${trip.budget.currency}`}
-                    </Text>
+                    <Text fw={700}>{formatCost({value: totalExpenses, currency: trip.budget.currency})}</Text>
                   </Group>
                 </Box>
               </Group>

--- a/src/components/trip/expenses/ExpenseCard.tsx
+++ b/src/components/trip/expenses/ExpenseCard.tsx
@@ -8,6 +8,7 @@ import { useSurmaiContext } from '../../../app/useSurmaiContext.ts';
 import { getAttachmentUrl } from '../../../lib/api';
 
 import type { Attachment, ConvertedExpense } from '../../../types/trips.ts';
+import { formatCost } from './helper.ts';
 
 export const ExpenseCard = ({
   expense,
@@ -85,7 +86,7 @@ export const ExpenseCard = ({
                 {t('amount', 'Amount')}:
               </Text>
               <Text size="sm" fw={600} c="blue">
-                {expense.convertedCost.value} {expense.convertedCost.currency}
+                {formatCost(expense.convertedCost)}
               </Text>
             </Group>
           )}

--- a/src/components/trip/expenses/ExpenseStatCards.tsx
+++ b/src/components/trip/expenses/ExpenseStatCards.tsx
@@ -1,7 +1,7 @@
 import { Anchor, Card, Group, RingProgress, SimpleGrid, Stack, Text } from '@mantine/core';
 import { useTranslation } from 'react-i18next';
 
-import { getRandomColor } from './helper.ts';
+import { formatCost, getRandomColor } from './helper.ts';
 
 import type { ConvertedExpense, Trip } from '../../../types/trips.ts';
 
@@ -72,7 +72,7 @@ export const ExpenseStatCards = ({
                       {t('used', 'Used')}:
                     </Text>
                     <Text size="sm" fw={600}>
-                      {totalExpenses.toFixed(2)} {budgetCurrency}
+                      {formatCost({value: totalExpenses, currency: budgetCurrency})}
                     </Text>
                   </Group>
                   <Group justify="space-between">
@@ -80,7 +80,7 @@ export const ExpenseStatCards = ({
                       {t('budget', 'Budget')}:
                     </Text>
                     <Text size="sm" fw={600}>
-                      {budgetAmount.toFixed(2)} {budgetCurrency}
+                      {formatCost({value: budgetAmount, currency: budgetCurrency})}
                     </Text>
                   </Group>
                   <Group justify="space-between">
@@ -88,7 +88,7 @@ export const ExpenseStatCards = ({
                       {t('remaining', 'Remaining')}:
                     </Text>
                     <Text size="sm" fw={600} c={budgetAmount - totalExpenses < 0 ? 'red' : 'green'}>
-                      {(budgetAmount - totalExpenses).toFixed(2)} {budgetCurrency}
+                      {formatCost({value: budgetAmount - totalExpenses, currency: budgetCurrency})}
                     </Text>
                   </Group>
                 </Stack>
@@ -125,7 +125,7 @@ export const ExpenseStatCards = ({
                   return {
                     value: percentage,
                     color: color,
-                    tooltip: `${categoryData[category]?.label}: ${amount.toFixed(2)} ${budgetCurrency}`,
+                    tooltip: `${formatCost({value: amount, currency: budgetCurrency})}`
                   };
                 })}
                 label={
@@ -168,7 +168,7 @@ export const ExpenseStatCards = ({
                           {percentage.toFixed(1)}%
                         </Text>
                         <Text size="sm" fw={600}>
-                          {amount.toFixed(2)} {budgetCurrency}
+                          {formatCost({value: amount, currency: budgetCurrency})}
                         </Text>
                       </Group>
                     </Group>
@@ -202,7 +202,7 @@ export const ExpenseStatCards = ({
                   return {
                     value: percentage,
                     color: color,
-                    tooltip: `${amount.total.toFixed(2)} ${currencyCode}`,
+                    tooltip: `${formatCost({value: amount.total, currency: currencyCode})}`
                   };
                 })}
                 label={
@@ -234,7 +234,7 @@ export const ExpenseStatCards = ({
                           }}
                         />
                         <Text size="sm" fw={500}>
-                          {`${currencyCode} ${amount.total.toFixed(2)} `}
+                          {formatCost({value: amount.total, currency: currencyCode})}
                         </Text>
                       </Group>
                       <Group gap="xs" wrap="nowrap">

--- a/src/components/trip/expenses/helper.ts
+++ b/src/components/trip/expenses/helper.ts
@@ -1,6 +1,6 @@
 import { type User } from '../../../types/auth';
 import { type ConversionRate } from '../../../types/expenses';
-import { type ConvertedExpense, type Expense, type Trip } from '../../../types/trips';
+import { type ConvertedExpense, type Expense, type Trip, type Cost } from '../../../types/trips';
 
 export const convertExpenses = (
   user: User | undefined,
@@ -80,3 +80,7 @@ export const getRandomColor = (code: string) => {
 
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
 };
+
+export const formatCost = (cost: Cost | undefined) => {
+  return cost ? cost.value.toLocaleString(undefined, { style: "currency", currency: cost.currency }) : "";
+}

--- a/src/components/trip/itinerary/pdfGenerator.ts
+++ b/src/components/trip/itinerary/pdfGenerator.ts
@@ -9,6 +9,7 @@ import type { Activity, Lodging, Transportation, Trip, ItineraryLine, TravellerP
 import { formatDateTime } from '../../../lib/time.ts';
 import type { TDocumentDefinitions, Content } from 'pdfmake/interfaces';
 import { User } from '../../../types/auth.ts';
+import { formatCost } from '../expenses/helper.ts';
 
 // @ts-expect-error pdfmake fonts
 pdfMake.vfs = pdfFonts.pdfMake ? pdfFonts.pdfMake.vfs : (pdfFonts as any).vfs;
@@ -98,7 +99,7 @@ const formatTransportation = (transportation: Transportation, tripTravellers: Tr
                   : '',
                 transportation.cost?.value
                   ? {
-                      text: `${i18n.t('cost', 'Cost')}: ${transportation.cost.value} ${transportation.cost.currency}`,
+                      text: `${i18n.t('cost', 'Cost')}: ${formatCost(transportation.cost)}`,
                       fontSize: 9,
                       color: TEXT_COLOR,
                     }
@@ -190,7 +191,7 @@ const formatTransportation = (transportation: Transportation, tripTravellers: Tr
                     : '',
                   transportation.cost?.value
                     ? {
-                        text: `${i18n.t('cost', 'Cost')}: ${transportation.cost.value} ${transportation.cost.currency}`,
+                        text: `${i18n.t('cost', 'Cost')}: ${formatCost(transportation.cost)}`,
                         fontSize: 9,
                         color: TEXT_COLOR,
                       }
@@ -279,7 +280,7 @@ const formatLodging = (l: Lodging, tripTravellers: TravellerProfile[], user: Use
                     : '',
                   l.cost?.value
                     ? {
-                        text: `${i18n.t('cost', 'Cost')}: ${l.cost.value} ${l.cost.currency}`,
+                        text: `${i18n.t('cost', 'Cost')}: ${formatCost(l.cost)}`,
                         fontSize: 9,
                         color: TEXT_COLOR,
                       }
@@ -350,7 +351,7 @@ const formatActivity = (a: Activity, tripTravellers: TravellerProfile[], user: U
                   { text: `${i18n.t('time', 'Time')}: ${formatDateTime(a.startDate, user)}`, fontSize: 10 },
                   a.cost?.value
                     ? {
-                        text: `${i18n.t('cost', 'Cost')}: ${a.cost.value} ${a.cost.currency}`,
+                        text: `${i18n.t('cost', 'Cost')}: ${formatCost(a.cost)}`,
                         fontSize: 10,
                       }
                     : '',

--- a/src/components/trip/lodging/GenericLodgingData.tsx
+++ b/src/components/trip/lodging/GenericLodgingData.tsx
@@ -17,6 +17,7 @@ import { GenericLodgingForm } from './GenericLodgingForm.tsx';
 import { typeIcons } from './typeIcons.ts';
 
 import type { Attachment, Expense, Lodging, TravellerProfile, Trip } from '../../../types/trips.ts';
+import { formatCost } from '../expenses/helper.ts';
 
 export const GenericLodgingData = ({
   trip,
@@ -46,8 +47,6 @@ export const GenericLodgingData = ({
 
   // Get expense from map, handle null/undefined cases
   const expense = lodging.expenseId ? expenseMap.get(lodging.expenseId) : undefined;
-  const costValue = expense?.cost?.value;
-  const costCurrency = expense?.cost?.currency;
 
   return (
     <DataLine
@@ -169,7 +168,7 @@ export const GenericLodgingData = ({
           <Text size="xs" c={'dimmed'}>
             {t('cost', 'Cost')}
           </Text>
-          <Text size="md">{costValue ? `${costValue} ${costCurrency || ''}` : ''}</Text>
+          <Text size="md">{formatCost(expense?.cost)}</Text>
         </Grid.Col>
       </Grid>
       <TravellerBadges travellerIds={lodging.travellers} tripTravellers={tripTravellers} />

--- a/src/components/trip/transportation/FlightData.tsx
+++ b/src/components/trip/transportation/FlightData.tsx
@@ -16,6 +16,7 @@ import { TravellerBadges } from '../TravellerBadges.tsx';
 
 import type { Attachment, Expense, Transportation, TravellerProfile, Trip } from '../../../types/trips.ts';
 import { useCurrentUser } from '../../../auth/useCurrentUser.ts';
+import { formatCost } from '../expenses/helper.ts';
 
 export const FlightData = ({
   trip,
@@ -43,8 +44,6 @@ export const FlightData = ({
 
   // Get expense from map, handle null/undefined cases
   const expense = transportation.expenseId ? expenseMap.get(transportation.expenseId) : undefined;
-  const costValue = expense?.cost?.value;
-  const costCurrency = expense?.cost?.currency;
 
   return (
     <DataLine
@@ -207,7 +206,7 @@ export const FlightData = ({
           <Text size="xs" c={'dimmed'}>
             {t('cost', 'Cost')}
           </Text>
-          <Text size="md">{costValue ? `${costValue} ${costCurrency || ''}` : ''}</Text>
+          <Text size="md">{formatCost(expense?.cost)}</Text>
         </Grid.Col>
       </Grid>
       <TravellerBadges travellerIds={transportation.travellers} tripTravellers={tripTravellers} />

--- a/src/components/trip/transportation/GenericTransportationData.tsx
+++ b/src/components/trip/transportation/GenericTransportationData.tsx
@@ -18,6 +18,7 @@ import { typeIcons } from './typeIcons.ts';
 
 import type { Attachment, Expense, Transportation, TravellerProfile, Trip } from '../../../types/trips.ts';
 import { useCurrentUser } from '../../../auth/useCurrentUser.ts';
+import { formatCost } from '../expenses/helper.ts';
 
 export const GenericTransportationData = ({
   trip,
@@ -49,8 +50,6 @@ export const GenericTransportationData = ({
 
   // Get expense from map, handle null/undefined cases
   const expense = transportation.expenseId ? expenseMap.get(transportation.expenseId) : undefined;
-  const costValue = expense?.cost?.value;
-  const costCurrency = expense?.cost?.currency;
 
   return (
     <DataLine
@@ -233,7 +232,7 @@ export const GenericTransportationData = ({
           <Text size="xs" c={'dimmed'}>
             {t('cost', 'Cost')}
           </Text>
-          <Text size="md">{costValue ? `${costValue} ${costCurrency || ''}` : ''}</Text>
+          <Text size="md">{formatCost(expense?.cost)}</Text>
         </Grid.Col>
       </Grid>
       <TravellerBadges travellerIds={transportation.travellers} tripTravellers={tripTravellers} />

--- a/src/pages/TravelBoard/TravelBoard.tsx
+++ b/src/pages/TravelBoard/TravelBoard.tsx
@@ -30,6 +30,7 @@ import { listAllTrips } from '../../lib/api';
 import { usePageTitle } from '../../lib/hooks/usePageTitle';
 
 import type { Trip } from '../../types/trips';
+import { formatCost } from '../../components/trip/expenses/helper';
 
 // Fix for default marker icons in Leaflet with Webpack/Vite
 
@@ -128,7 +129,7 @@ const TravelBoard = () => {
               <StatsCard title={t('days', 'Days')} value={filteredData.totalDays} />
               <StatsCard
                 title={t('cost', 'Cost')}
-                value={`${filteredData.totalExpenseAmount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${filteredData.userCurrency}`}
+                value={`${formatCost({value: filteredData.totalExpenseAmount, currency: filteredData.userCurrency})}`}
                 note={
                   filteredData.isDefaultCurrency
                     ? t('default_currency_note', 'Showing in USD (default) because no currency is set in your profile.')
@@ -260,11 +261,7 @@ const TravelBoard = () => {
                         <Group key={currency} justify="space-between">
                           <Text size="sm">{currency}</Text>
                           <Text size="sm" fw={500}>
-                            {amount.toLocaleString(undefined, {
-                              minimumFractionDigits: 2,
-                              maximumFractionDigits: 2,
-                            })}{' '}
-                            {currency}
+                            {formatCost({value: Number(amount), currency: currency})}
                           </Text>
                         </Group>
                       ))}


### PR DESCRIPTION
- Use `toLocaleString` to standardize cost formatting
- Currencies that don't use minor subdivisions (e.g. JPY, KRW) won't have decimals
- Currencies that do will properly have 2 decimal digits
- Currencies will use their correct symbol if available (e.g. $, ₩‎, €)